### PR TITLE
Simulation Ended Event

### DIFF
--- a/examples/multi_agent_llm_storytelling/processes.py
+++ b/examples/multi_agent_llm_storytelling/processes.py
@@ -15,7 +15,7 @@
 from gpt_json import GPTMessage, GPTMessageRole
 
 from hades import Event, Process
-from hades.core.event import Event, SimulationStarted
+from hades.core.event import Event, SimulationEnded, SimulationStarted
 from hades.core.process import NotificationResponse
 
 from .events import CharacterActed, StoryUnfolded, SynthesisedEventsOfDay
@@ -63,6 +63,9 @@ class Homer(Process):
                 except KeyError:
                     self._events_of_day[e.t] = [e]
                     self.add_event(SynthesisedEventsOfDay(t=e.t + 1, day=e.t))
+                return NotificationResponse.ACK
+            case SimulationEnded():
+                print(self.story_so_far)
                 return NotificationResponse.ACK
         return NotificationResponse.NO_ACK
 

--- a/hades/__init__.py
+++ b/hades/__init__.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 """HADES Asynchronous Discrete-Event Simulation"""
-from hades.core.event import Event, ProcessUnregistered, SimulationStarted
+from hades.core.event import Event, ProcessUnregistered, SimulationEnded, SimulationStarted
 from hades.core.hades import Hades
 from hades.core.process import NotificationResponse, PredefinedEventAdder, Process, RandomProcess
 
 __all__ = [
     "Event",
     "SimulationStarted",
+    "SimulationEnded",
     "ProcessUnregistered",
     "PredefinedEventAdder",
     "Hades",

--- a/hades/core/event.py
+++ b/hades/core/event.py
@@ -80,3 +80,7 @@ class ProcessUnregistered(Event):
     special event for unregistered the process who sent this event.
     it is unique in that it will be consumed by hades and not broadcast to other processes.
     """
+
+
+class SimulationEnded(Event):
+    """Signals the simulation has ended."""

--- a/hades/core/hades.py
+++ b/hades/core/hades.py
@@ -25,7 +25,7 @@ from itertools import count, product
 from queue import Empty, PriorityQueue
 from typing import Any, Coroutine
 
-from hades.core.event import Event, ProcessUnregistered, SimulationStarted
+from hades.core.event import Event, ProcessUnregistered, SimulationEnded, SimulationStarted
 from hades.core.process import HadesInternalProcess, NotificationResponse, Process
 
 _logger = logging.getLogger(__name__)
@@ -246,3 +246,7 @@ class Hades:
         continue_running = True
         while continue_running:
             continue_running = await self.step(until=until)
+        self.add_event(hades_process, SimulationEnded(t=self.t))
+        # Always broadcast the SimulationEnded event.
+        # Even if we have gone beyond the end of time.
+        await self.step(until=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hades-framework"
-version = "1.0.3"
+version = "1.0.4"
 description = "Hades Asynchronous Discrete-Event Simulation"
 authors = ["Ki Insurance Team", "Reuben Thomas-Davis <Reuben.Thomas-Davis@ki-insurance.com>", "Keith Kam <keith.kam@accenture.com>"]
 license = "Apache License 2.0"

--- a/tests/test_hades.py
+++ b/tests/test_hades.py
@@ -150,7 +150,7 @@ async def test_runs_till_events_exhausted():
     hades.add_event(UniqueProcess(), E2(t=1000))
     await hades.run()
     assert hades.t == 1000
-    assert len(hades.event_history) == 3
+    assert len(hades.event_history) == 4
 
 
 async def test_runs_till_until_param():
@@ -160,7 +160,7 @@ async def test_runs_till_until_param():
     hades.add_event(UniqueProcess(), E2(t=1000))
     await hades.run(until=500)
     assert hades.t == 1000
-    assert len(hades.event_history) == 2
+    assert len(hades.event_history) == 3
 
 
 @patch("hades.core.hades.inspect.currentframe", lambda: None)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -54,5 +54,13 @@ DEBUG    hades.core.hades [t=738885] completed task notify process: HadesInterna
 DEBUG    hades.core.hades [t=738885] getting events for next timestamp
 DEBUG    hades.core.hades [t=738885] got 0 events at time 738885
 INFO     hades.core.hades [t=738885] ending run as we have exhausted the queue of events!
+DEBUG    hades.core.hades [t=738885] adding SimulationEnded from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 (caused by None) to queue
+DEBUG    hades.core.hades [t=738885] getting events for next timestamp
+DEBUG    hades.core.hades [t=738885] added event=SimulationEnded(t=738885) to next events batch
+DEBUG    hades.core.hades [t=738885] got 1 events at time 738885
+DEBUG    hades.time.process [t=738885] adding look ahead YearStarted events between 2025 and 2026 due to SimulationEnded(t=738885)
+DEBUG    hades.core.hades [t=738885] adding YearStarted from process: YearStartScheduler, instance: 332231294394531790607923355838092946842 (caused by None) to queue
+DEBUG    hades.core.hades [t=738885] completed task notify process: YearStartScheduler, instance: 332231294394531790607923355838092946842 of t=738885 from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 with result NotificationResponse.ACK
+DEBUG    hades.core.hades [t=738885] completed task notify process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 of t=738885 from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 with result NotificationResponse.NO_ACK
 """
     )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -14,8 +14,16 @@
 
 import pytest
 
-from hades import Event, Hades, PredefinedEventAdder, Process, ProcessUnregistered, RandomProcess, SimulationStarted
-from hades.core.event import SimulationEnded
+from hades import (
+    Event,
+    Hades,
+    PredefinedEventAdder,
+    Process,
+    ProcessUnregistered,
+    RandomProcess,
+    SimulationEnded,
+    SimulationStarted,
+)
 from hades.core.process import NotificationResponse
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -15,6 +15,7 @@
 import pytest
 
 from hades import Event, Hades, PredefinedEventAdder, Process, ProcessUnregistered, RandomProcess, SimulationStarted
+from hades.core.event import SimulationEnded
 from hades.core.process import NotificationResponse
 
 
@@ -48,6 +49,7 @@ async def test_predefined_event_adder_adds_events_to_hades():
         ProcessUnregistered(t=0),
         Event(t=2),
         Event(t=3),
+        SimulationEnded(t=3),
     ]
 
 

--- a/tests/time/test_logging.py
+++ b/tests/time/test_logging.py
@@ -55,5 +55,13 @@ DEBUG    hades.core.hades [2024-01-01] completed task notify process: HadesInter
 DEBUG    hades.core.hades [2024-01-01] getting events for next timestamp
 DEBUG    hades.core.hades [2024-01-01] got 0 events at time 738885
 INFO     hades.core.hades [2024-01-01] ending run as we have exhausted the queue of events!
+DEBUG    hades.core.hades [2024-01-01] adding SimulationEnded from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 (caused by None) to queue
+DEBUG    hades.core.hades [2024-01-01] getting events for next timestamp
+DEBUG    hades.core.hades [2024-01-01] added event=SimulationEnded(t=738885) to next events batch
+DEBUG    hades.core.hades [2024-01-01] got 1 events at time 738885
+DEBUG    hades.time.process [2024-01-01] adding look ahead YearStarted events between 2025 and 2026 due to SimulationEnded(t=738885)
+DEBUG    hades.core.hades [2024-01-01] adding YearStarted from process: YearStartScheduler, instance: 332231294394531790607923355838092946842 (caused by None) to queue
+DEBUG    hades.core.hades [2024-01-01] completed task notify process: YearStartScheduler, instance: 332231294394531790607923355838092946842 of t=738885 from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 with result NotificationResponse.ACK
+DEBUG    hades.core.hades [2024-01-01] completed task notify process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 of t=738885 from process: HadesInternalProcess, instance: 7836064115094481643618470001379502846 with result NotificationResponse.NO_ACK
 """
     )

--- a/tests/visualisation/test_networkx.py
+++ b/tests/visualisation/test_networkx.py
@@ -43,6 +43,11 @@ async def test_hades_process_events_to_digraph_for_simple_sim(simple_sim):
             0,
         ),
         (
+            "HadesInternalProcess - 7970269937446031133269215595648805179",
+            "YearStartScheduler - 332231294394531790607923355838092946842",
+            1,
+        ),
+        (
             "YearStartScheduler - 332231294394531790607923355838092946842",
             "QuarterStartScheduler - 7836064115094481643618470001379502846",
             0,
@@ -56,6 +61,7 @@ def test_digraph_to_mermaid_for_simple_sim(simple_sim):
     assert (
         write_mermaid(to_digraph(simple_sim))
         == """graph LR
+HadesInternalProcess-7970269937446031133269215595648805179(HadesInternalProcess - 7970269937446031133269215595648805179) -- SimulationEnded --> YearStartScheduler-332231294394531790607923355838092946842(YearStartScheduler - 332231294394531790607923355838092946842)
 HadesInternalProcess-7970269937446031133269215595648805179(HadesInternalProcess - 7970269937446031133269215595648805179) -- SimulationStarted --> YearStartScheduler-332231294394531790607923355838092946842(YearStartScheduler - 332231294394531790607923355838092946842)
 YearStartScheduler-332231294394531790607923355838092946842(YearStartScheduler - 332231294394531790607923355838092946842) -- YearStarted --> QuarterStartScheduler-7836064115094481643618470001379502846(QuarterStartScheduler - 7836064115094481643618470001379502846)"""
     )

--- a/tests/visualisation/test_websockets.py
+++ b/tests/visualisation/test_websockets.py
@@ -70,6 +70,7 @@ async def test_websockets_process_broadcasts_correct_events():
         '{"event_type": "QuarterStarted", "event_contents": {"t": 738610}}',
         '{"event_type": "QuarterStarted", "event_contents": {"t": 738701}}',
         '{"event_type": "QuarterStarted", "event_contents": {"t": 738793}}',
+        '{"event_type": "SimulationEnded", "event_contents": {"t": 738793}}',
     ]
 
 
@@ -320,6 +321,30 @@ async def test_hades_websockets(caplog):
             ' "instance_identifier": "7970269937446031133269215595648805179"}, "event": {"event_type":'
             ' "QuarterStarted", "event_contents": {"t": 738793}}, "target_process_response": 3, "causing_event":'
             ' {"event_type": "YearStarted", "event_contents": {"t": 738520}}}'
+        ),
+        (
+            '{"source_process": {"process_name": "HadesInternalProcess", '
+            '"instance_identifier": "7970269937446031133269215595648805179"}, '
+            '"target_process": {"process_name": "YearStartScheduler", '
+            '"instance_identifier": "332231294394531790607923355838092946842"}, "event": '
+            '{"event_type": "SimulationEnded", "event_contents": {"t": 738793}}, '
+            '"target_process_response": 1, "causing_event": null}'
+        ),
+        (
+            '{"source_process": {"process_name": "HadesInternalProcess", '
+            '"instance_identifier": "7970269937446031133269215595648805179"}, '
+            '"target_process": {"process_name": "QuarterStartScheduler", '
+            '"instance_identifier": "7836064115094481643618470001379502846"}, "event": '
+            '{"event_type": "SimulationEnded", "event_contents": {"t": 738793}}, '
+            '"target_process_response": 3, "causing_event": null}'
+        ),
+        (
+            '{"source_process": {"process_name": "HadesInternalProcess", '
+            '"instance_identifier": "7970269937446031133269215595648805179"}, '
+            '"target_process": {"process_name": "HadesInternalProcess", '
+            '"instance_identifier": "7970269937446031133269215595648805179"}, "event": '
+            '{"event_type": "SimulationEnded", "event_contents": {"t": 738793}}, '
+            '"target_process_response": 3, "causing_event": null}'
         ),
     ]
 


### PR DESCRIPTION
**Objective**: Make it easier to store process final state.

---

Useful for processes do some "clean-up"; store their final state, tear something down, play a little tune, ...

- Difficult as a process to know the simulation has ended and it is time to start thinking about cleaning up.
- Difficult as `Hades` to know _how_ to clean-up processes and _which_ to clean-up.

Alternatives:

- Require a `clean_up` / `tear_down` method on processes - but what args? What if process has no clean-up?
- Do nothing
    - You have the `Hades[WS]` instance(s) and do with it what you wish.
    - Can always write the individual events as they come in which will likely offer a path to achieve writing whatever state you would be writing at clean-up time.
        - doesn't help if you need to do any genuine clean-up
        - and you may not want to store every event - perhaps only the final state is interesting.

Assorted other bullets:
- Precedence for this type of "sentinel" event e.g. `SimulationStarted`.

---

Implementation

- Value for `t`?
- Implement in `Hades.step`?
- Implement in `Hades.run`?

---

WIP until

- [x] better motivating example with code
- [x] tests ofc